### PR TITLE
Proposing new groupId under FINOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.github.deutschebank.symphony</groupId>
+	<groupId>org.finos.symphony</groupId>
 	<artifactId>symphony-java-client-parent</artifactId>
 	<version>4.59.7-SNAPSHOT</version>
 	<packaging>pom</packaging>


### PR DESCRIPTION
We generally recommend projects to align groupId to be under the org.finos namespace. 

I realize though you might want to contextually consider [artifact relocation](https://maven.apache.org/guides/mini/guide-relocation.html) (even though it seems that it's being reworked in 2020).

Just an idea to be even further part of the FINOS family :) /cc @maoo 